### PR TITLE
Remove describe jobflow from common path, raise exception when called

### DIFF
--- a/elastic-mapreduce.gemspec
+++ b/elastic-mapreduce.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "elastic-mapreduce"
-  s.version = "2015.06.08"
+  s.version = "2016.01.25"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Amazon.com", "Koichi Fujikawa"]
-  s.date = "2012-06-28"
+  s.date = "2016-01-25"
   s.description = "Original is official but this is Unofficial gem."
   s.email = "fujibee@hapyrus.com"
   s.executables = ["elastic-mapreduce"]

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -56,6 +56,7 @@ class EmrClient
   end
 
   def describe_jobflow_with_id(jobflow_id)
+    raise "DescribeJobFlows is deprecated"
     logger.trace "DescribeJobFlows('JobFlowIds' => [ #{jobflow_id} ])"
     result = @client.DescribeJobFlows('JobFlowIds' => [ jobflow_id ], 'DescriptionType' => 'EXTENDED')
     logger.trace result.inspect
@@ -81,6 +82,7 @@ class EmrClient
   end
 
   def describe_jobflow(options)
+    raise "DescribeJobFlows is deprecated"
     logger.trace "DescribeJobFlows(#{options.inspect})"
     result = @client.DescribeJobFlows(options.merge('DescriptionType' => 'EXTENDED'))
     logger.trace result.inspect

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -10,7 +10,7 @@ require 'open3'
 
 module Commands
 
-  ELASTIC_MAPREDUCE_CLIENT_VERSION = "2015-06-08"
+  ELASTIC_MAPREDUCE_CLIENT_VERSION = "2016-01-25"
   DEFAULT_JOB_FLOW_ROLE = 'EMR_EC2_DefaultRole'
   DEFAULT_SERVICE_ROLE = 'EMR_DefaultRole'
   DEFAULT_AMI_VERSION = '2.4.6'
@@ -782,8 +782,7 @@ module Commands
 
     def enact(client)
       jobflow_id = require_single_jobflow
-      jobflow = client.describe_jobflow_with_id(jobflow_id)
-      self.step_commands = reorder_steps(jobflow, self.step_commands)
+      self.step_commands = reorder_steps(nil, self.step_commands)
       jobflow_steps = step_commands.map { |x| x.steps }.flatten
       client.add_steps(jobflow_id, jobflow_steps)
       logger.puts("Added jobflow steps")


### PR DESCRIPTION
The only reorder_steps commands that require the jobflow object are Hive and Pig steps. They use the jobflow object to decide whether or not to insert a Hive or Pig set up step. We know we don't use these interfaces, so just remove the call to describe jobflows. Also, make sure any unexpected call to describe job flows kills the pipeline with a stacktrace. 
